### PR TITLE
Updates per Synthetix' feedback

### DIFF
--- a/contracts/Settler.vy
+++ b/contracts/Settler.vy
@@ -22,10 +22,12 @@ interface RegistrySwap:
     ) -> uint256: payable
 
 interface Synthetix:
-    def exchange(
+    def exchangeWithTracking(
         sourceCurrencyKey: bytes32,
         sourceAmount: uint256,
         destinationCurrencyKey: bytes32,
+        originator: address,
+        trackingCode: bytes32,
     ): nonpayable
     def settle(currencyKey: bytes32) -> uint256[3]: nonpayable
 
@@ -35,6 +37,7 @@ interface Synth:
 
 ADDRESS_PROVIDER: constant(address) = 0x0000000022D53366457F9d5E68Ec105046FC4383
 SNX: constant(address) = 0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F
+TRACKING_CODE: constant(bytes32) = 0x4355525645000000000000000000000000000000000000000000000000000000
 
 is_approved: HashMap[address, HashMap[address, bool]]
 
@@ -66,7 +69,7 @@ def convert_synth(
     assert msg.sender == self.admin
 
     self.synth = _target
-    Synthetix(SNX).exchange(_source_key, _amount, _dest_key)
+    Synthetix(SNX).exchangeWithTracking(_source_key, _amount, _dest_key, msg.sender, TRACKING_CODE)
 
     return True
 

--- a/contracts/SynthSwap.vy
+++ b/contracts/SynthSwap.vy
@@ -33,6 +33,9 @@ interface RegistrySwap:
         _receiver: address,
     ) -> uint256: payable
 
+interface SNXAddressResolver:
+    def getAddress(name: bytes32) -> address: view
+
 interface Synth:
     def currencyKey() -> bytes32: nonpayable
 
@@ -111,7 +114,9 @@ struct TokenInfo:
 
 
 ADDRESS_PROVIDER: constant(address) = 0x0000000022D53366457F9d5E68Ec105046FC4383
-EXCHANGER: constant(address) = 0x0bfDc04B38251394542586969E2356d0D731f7DE
+
+SNX_ADDRESS_RESOLVER: constant(address) = 0x823bE81bbF96BEc0e25CA13170F5AaCb5B79ba83
+EXCHANGER_KEY: constant(bytes32) = 0x45786368616e6765720000000000000000000000000000000000000000000000
 
 # token id -> owner
 id_to_owner: HashMap[uint256, address]
@@ -137,6 +142,9 @@ is_approved: HashMap[address, HashMap[address, bool]]
 # synth -> currency key
 currency_keys: HashMap[address, bytes32]
 
+# Synthetix exchanger contract
+exchanger: Exchanger
+
 
 @external
 def __init__(_settler_implementation: address, _settler_count: uint256):
@@ -156,6 +164,7 @@ def __init__(_settler_implementation: address, _settler_count: uint256):
         log NewSettler(settler)
 
     self.settler_count = _settler_count
+    self.exchanger = Exchanger(SNXAddressResolver(SNX_ADDRESS_RESOLVER).getAddress(EXCHANGER_KEY))
 
 
 @view
@@ -331,7 +340,7 @@ def _get_swap_into(_from: address, _synth: address, _amount: uint256) -> uint256
 
         synth_amount = Curve(pool).get_dy(i, j, _amount)
 
-    return Exchanger(EXCHANGER).getAmountsForExchange(
+    return self.exchanger.getAmountsForExchange(
         synth_amount,
         self.currency_keys[intermediate_synth],
         self.currency_keys[_synth],
@@ -561,7 +570,7 @@ def swap_from_synth(
     # ensure the synth is settled prior to swapping
     if not self.is_settled[_token_id]:
         currency_key: bytes32 = self.currency_keys[synth]
-        Exchanger(EXCHANGER).settle(settler, currency_key)
+        self.exchanger.settle(settler, currency_key)
         self.is_settled[_token_id] = True
 
     # use Curve to exchange the synth for another asset which is sent to the receiver
@@ -611,7 +620,7 @@ def withdraw(_token_id: uint256, _amount: uint256, _receiver: address = msg.send
     # ensure the synth is settled prior to withdrawal
     if not self.is_settled[_token_id]:
         currency_key: bytes32 = self.currency_keys[synth]
-        Exchanger(EXCHANGER).settle(settler, currency_key)
+        self.exchanger.settle(settler, currency_key)
         self.is_settled[_token_id] = True
 
     remaining: uint256 = Settler(settler).withdraw(_receiver, _amount)
@@ -648,7 +657,7 @@ def settle(_token_id: uint256) -> bool:
         settler: address = convert(_token_id, address)
         synth: address = Settler(settler).synth()
         currency_key: bytes32 = self.currency_keys[synth]
-        Exchanger(EXCHANGER).settle(settler, currency_key)  # dev: settlement failed
+        self.exchanger.settle(settler, currency_key)  # dev: settlement failed
         self.is_settled[_token_id] = True
 
     return True
@@ -708,8 +717,16 @@ def token_info(_token_id: uint256) -> TokenInfo:
         currency_key: bytes32 = self.currency_keys[info.synth]
         reclaim: uint256 = 0
         rebate: uint256 = 0
-        reclaim, rebate = Exchanger(EXCHANGER).settlementOwing(settler, currency_key)
+        reclaim, rebate = self.exchanger.settlementOwing(settler, currency_key)
         info.underlying_balance = info.underlying_balance - reclaim + rebate
-        info.time_to_settle = Exchanger(EXCHANGER).maxSecsLeftInWaitingPeriod(settler, currency_key)
+        info.time_to_settle = self.exchanger.maxSecsLeftInWaitingPeriod(settler, currency_key)
 
     return info
+
+
+@external
+def rebuildCache():
+    """
+    @notice Update the current address of the SNX Exchanger contract
+    """
+    self.exchanger = Exchanger(SNXAddressResolver(SNX_ADDRESS_RESOLVER).getAddress(EXCHANGER_KEY))

--- a/tests/unitary/test_add_synth.py
+++ b/tests/unitary/test_add_synth.py
@@ -1,14 +1,12 @@
 import brownie
-from brownie import ZERO_ADDRESS
 
 
 def test_add_synth(alice, swap, sUSD, curve_susd):
     swap.add_synth(sUSD, curve_susd, {'from': alice})
 
     assert swap.synth_pools(sUSD) == curve_susd
-    for coin in [curve_susd.coins(i) for i in range(3)]:
+    for coin in [curve_susd.coins(i) for i in range(4)]:
         assert swap.swappable_synth(coin) == sUSD
-    assert swap.swappable_synth(sUSD) == ZERO_ADDRESS
 
 
 def test_already_added(alice, swap, sUSD, curve_susd):


### PR DESCRIPTION
### What I did
Updates and fixes based on feedback from @justinjmoses

- Call SNX address resolver to get `Exchanger` address, add a `rebuildCache` function to update the local address if it changes from an upgrade
- Perform swaps via `exchangeWithTracking` and include curve tracking code
- Consider rebate/reclaim amounts when calculating balance for unsettled synths